### PR TITLE
Add current working dir to PYTHONPATH when testing

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 export PACKAGE=mkdocs2
+export PYTHONPATH=.:${PYTHONPATH}
 export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,7 @@
 
 export PACKAGE=mkdocs2
 export PYTHONPATH=.:${PYTHONPATH}
+export PYTHONVERSION=`python -c 'import sys; print("%d.%d" % sys.version_info[:2])'`
 export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
@@ -11,4 +12,6 @@ set -x
 
 ${PREFIX}pytest --cov ${PACKAGE} --cov tests --cov-fail-under 100 ./tests/
 ${PREFIX}mypy --ignore-missing-imports --disallow-untyped-defs ${PACKAGE}
-${PREFIX}black ${PACKAGE} tests --check
+if [[ ${PYTHONVERSION} == "3.6" ]]; then
+    ${PREFIX}black ${PACKAGE} tests --check
+fi


### PR DESCRIPTION
* Add current working dir to PYTHONPATH when testing
* Limit `black` to Python 3.6 (https://github.com/ambv/black/issues/494)