### PR TITLE
Autodoc Extension

### DIFF
--- a/example/docs/css/base.css
+++ b/example/docs/css/base.css
@@ -18,3 +18,16 @@ container a:before {
     content: "";
     display:block;
 }
+
+code.autodoc-import {
+    color: black;
+}
+
+code.autodoc-name {
+    color: black;
+    font-weight: bold;
+}
+
+div.autodoc-docstring {
+    margin-left: 20px;
+}

--- a/example/docs/page-a.md
+++ b/example/docs/page-a.md
@@ -2,5 +2,8 @@
 
 This is some API documentation, using the autodoc extension.
 
-::: mkdocs2:build
+::: mkdocs2.build
+    :docstring:
+
+::: mkdocs2.types.File
     :docstring:

--- a/example/docs/page-a.md
+++ b/example/docs/page-a.md
@@ -1,0 +1,6 @@
+# API Documentation
+
+This is some API documentation, using the autodoc extension.
+
+::: mkdocs2:build
+    :docstring:

--- a/example/mkdocs.yml
+++ b/example/mkdocs.yml
@@ -14,6 +14,6 @@ nav:
         Topic C: topics/topic-c.md
 
 convertors:
-    - mkdocs2.convertors:MarkdownPages
-    - mkdocs2.convertors:StaticFiles
-    - mkdocs2.convertors:CodeHighlight
+    - mkdocs2.convertors.MarkdownPages
+    - mkdocs2.convertors.StaticFiles
+    - mkdocs2.convertors.CodeHighlight

--- a/mkdocs2/convertors/markdown_pages.py
+++ b/mkdocs2/convertors/markdown_pages.py
@@ -8,6 +8,7 @@ from markdown import Markdown
 from markdown.extensions.codehilite import CodeHiliteExtension
 from markdown.extensions.toc import TocExtension
 from markdown.extensions.fenced_code import FencedCodeExtension
+from mkdocs2.markdown_extensions.autodoc import AutoDocExtension
 from mkdocs2.markdown_extensions.convert_urls import ConvertURLs
 
 
@@ -55,6 +56,7 @@ class MarkdownPages(Convertor):
             extensions=[
                 TocExtension(permalink=True),
                 FencedCodeExtension(),
+                AutoDocExtension(),
                 CodeHiliteExtension(),
                 ConvertURLs(convert_url=url),
             ]

--- a/mkdocs2/core.py
+++ b/mkdocs2/core.py
@@ -7,6 +7,13 @@ import typing
 
 
 def build(config: typing.Dict) -> None:
+    """
+    Builds the documentation.
+
+    **Parameters:**
+
+    * `config` - A MkDocs configuration dictionary.
+    """
     base_url = config["build"].get("url")
     input_dir = config["build"]["input_dir"]
     output_dir = config["build"]["output_dir"]
@@ -115,17 +122,17 @@ def load_nav_items(
 
 
 def import_from_string(import_str: str) -> typing.Any:
-    module_str, _, attrs_str = import_str.partition(":")
+    module_str, _, attr_str = import_str.rpartition(".")
 
     try:
-        lookup = importlib.import_module(module_str)
+        module = importlib.import_module(module_str)
     except ImportError as exc:
+        module_name = module_str.split('.', 1)[0]
+        if exc.name != module_name:
+            raise exc from None
         raise ValueError(f"Could not import module {module_str!r}.")
 
     try:
-        for attr in attrs_str.split("."):
-            lookup = getattr(lookup, attr)
+        return getattr(module, attr_str)
     except AttributeError as exc:
-        raise ValueError(f"Attribute {attrs_str!r} not found in module {module_str!r}.")
-
-    return lookup
+        raise ValueError(f"Attribute {attr_str!r} not found in module {module_str!r}.")

--- a/mkdocs2/markdown_extensions/autodoc.py
+++ b/mkdocs2/markdown_extensions/autodoc.py
@@ -8,19 +8,106 @@ import re
 import typing
 
 
+def get_params(signature: inspect.Signature) -> typing.List[str]:
+    """
+    Given a function signature, return a list of parameter strings
+    to use in documentation.
+
+    Eg. test(a, b=None, **kwargs) -> ['a', 'b=None', '**kwargs']
+    """
+    params = []
+    render_pos_only_separator = True
+    render_kw_only_separator = True
+
+    for parameter in signature.parameters.values():
+        value = parameter.name
+        if parameter.default is not parameter.empty:
+            value = f'{value}={parameter.default!r}'
+
+        if parameter.kind is parameter.VAR_POSITIONAL:
+            render_kw_only_separator = False
+            value = f'*{value}'
+        elif parameter.kind is parameter.VAR_KEYWORD:
+            value = f'**{value}'
+        elif parameter.kind is parameter.POSITIONAL_ONLY:
+            if render_pos_only_separator:
+                render_pos_only_separator = False
+                params.append('/')
+        elif parameter.kind is parameter.KEYWORD_ONLY:
+            if render_kw_only_separator:
+                render_kw_only_separator = False
+                params.append('*')
+        params.append(value)
+
+    return params
+
+
+def last_iter(seq: typing.Sequence) -> typing.Iterator:
+    """
+    Given an sequence, return a two-tuple (item, is_last) iterable.
+
+    See: https://stackoverflow.com/a/1633483/596689
+    """
+    it = iter(seq)
+    item = next(it)
+    is_last = False
+
+    for next_item in it:
+        yield item, is_last
+        item = next_item
+
+    is_last = True
+    yield item, is_last
+
+
+def trim_docstring(docstring: typing.Optional[str]) -> str:
+    """
+    Trim leading indent from a docstring.
+
+    See: https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
+    """
+    if not docstring:
+        return ''
+
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    indent = 1000
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = min(indent, len(line) - len(stripped))
+
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    if indent < 1000:
+        for line in lines[1:]:
+            trimmed.append(line[indent:].rstrip())
+
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+
+    # Return a single string:
+    return '\n'.join(trimmed)
+
+
 class AutoDocProcessor(BlockProcessor):
 
     CLASSNAME = 'autodoc'
     RE = re.compile(r'(?:^|\n)::: ?([:a-zA-Z0-9_.]*) *(?:\n|$)')
     RE_SPACES = re.compile('  +')
 
-    def test(self, parent, block):
+    def test(self, parent: etree.Element, block: etree.Element) -> bool:
         sibling = self.lastChild(parent)
-        return self.RE.search(block) or \
+        return bool(self.RE.search(block) or \
             (block.startswith(' ' * self.tab_length) and sibling is not None and
-             sibling.get('class', '').find(self.CLASSNAME) != -1)
+             sibling.get('class', '').find(self.CLASSNAME) != -1))
 
-    def run(self, parent, blocks):
+    def run(self, parent: etree.Element, blocks: etree.Element) -> None:
         sibling = self.lastChild(parent)
         block = blocks.pop(0)
         m = self.RE.search(block)
@@ -53,7 +140,7 @@ class AutoDocProcessor(BlockProcessor):
             bracket_elem.text = '('
             bracket_elem.set('class', 'autodoc-punctuation')
 
-            for param, is_last in self.last_iter(self.get_params(attribute_signature)):
+            for param, is_last in last_iter(get_params(attribute_signature)):
                 param_elem = etree.SubElement(headline_elem, 'em')
                 param_elem.text = param
                 param_elem.set('class', 'autodoc-param')
@@ -71,95 +158,17 @@ class AutoDocProcessor(BlockProcessor):
             docstring_elem = etree.SubElement(autodoc_div, 'div')
             docstring_elem.set('class', 'autodoc-docstring')
 
-            docstring = self.trim(attribute.__doc__)
+            docstring = trim_docstring(attribute.__doc__)
             self.parser.parseChunk(docstring_elem, docstring)
 
-        else:
-            self.parser.parseChunk(sibling, block)
+        #else:
+        #    self.parser.parseChunk(sibling, block)
 
         if theRest:
             # This block contained unindented line(s) after the first indented
             # line. Insert these lines as the first block of the master blocks
             # list for future processing.
             blocks.insert(0, theRest)
-
-    def get_params(self, signature: inspect.Signature) -> typing.List[str]:
-        params = []
-        render_pos_only_separator = True
-        render_kw_only_separator = True
-
-        for parameter in signature.parameters.values():
-            value = parameter.name
-            if parameter.default is not parameter.empty:
-                value = f'{value}={parameter.default!r}'
-
-            if parameter.kind is parameter.VAR_POSITIONAL:
-                render_kw_only_separator = False
-                value = f'*{value}'
-            elif parameter.kind is parameter.VAR_KEYWORD:
-                value = f'**{value}'
-            elif parameter.kind is parameter.POSITIONAL_ONLY:
-                if render_pos_only_separator:
-                    render_pos_only_separator = False
-                    params.append('/')
-            elif parameter.kind is parameter.KEYWORD_ONLY:
-                if render_kw_only_separator:
-                    render_kw_only_separator = False
-                    params.append('*')
-            params.append(value)
-
-        return params
-
-    def last_iter(self, it: typing.Iterator) -> typing.Iterator:
-        """
-        Given an iteratable, return a two-tuple (item, is_last) iterable.
-
-        See: https://stackoverflow.com/a/1633483/596689
-        """
-        it = iter(it)
-        item = next(it)
-        is_last = False
-
-        for next_item in it:
-            yield item, is_last
-            item = next_item
-
-        is_last = True
-        yield item, is_last
-
-    def trim(self, docstring: typing.Optional[str]) -> str:
-        """
-        Trim leading indent from a docstring.
-
-        See: https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
-        """
-        if not docstring:
-            return ''
-
-        # Convert tabs to spaces (following the normal Python rules)
-        # and split into a list of lines:
-        lines = docstring.expandtabs().splitlines()
-        # Determine minimum indentation (first line doesn't count):
-        indent = 1000
-        for line in lines[1:]:
-            stripped = line.lstrip()
-            if stripped:
-                indent = min(indent, len(line) - len(stripped))
-
-        # Remove indentation (first line is special):
-        trimmed = [lines[0].strip()]
-        if indent < 1000:
-            for line in lines[1:]:
-                trimmed.append(line[indent:].rstrip())
-
-        # Strip off trailing and leading blank lines:
-        while trimmed and not trimmed[-1]:
-            trimmed.pop()
-        while trimmed and not trimmed[0]:
-            trimmed.pop(0)
-
-        # Return a single string:
-        return '\n'.join(trimmed)
 
 
 class AutoDocExtension(Extension):

--- a/mkdocs2/markdown_extensions/autodoc.py
+++ b/mkdocs2/markdown_extensions/autodoc.py
@@ -119,7 +119,7 @@ class AutoDocProcessor(BlockProcessor):
 
         if m:
             full_string = m.group(1)
-            import_string, _, name_string = full_string.partition(':')
+            import_string, _, name_string = full_string.rpartition('.')
             attribute = import_from_string(full_string)
             attribute_signature = inspect.signature(attribute)
 
@@ -128,6 +128,11 @@ class AutoDocProcessor(BlockProcessor):
 
             # Eg: `some_module.attribute_name`
             headline_elem = etree.SubElement(autodoc_div, 'p')
+
+            if inspect.isclass(attribute):
+                qualifier_elem = etree.SubElement(headline_elem, 'em')
+                qualifier_elem.text = "class "
+
             import_elem = etree.SubElement(headline_elem, 'code')
             import_elem.text = import_string + '.'
             import_elem.set('class', 'autodoc-import')

--- a/mkdocs2/markdown_extensions/autodoc.py
+++ b/mkdocs2/markdown_extensions/autodoc.py
@@ -1,0 +1,168 @@
+from markdown import Markdown
+from markdown.extensions import Extension
+from markdown.blockprocessors import BlockProcessor
+from markdown.util import etree
+from mkdocs2.core import import_from_string
+import inspect
+import re
+import typing
+
+
+class AutoDocProcessor(BlockProcessor):
+
+    CLASSNAME = 'autodoc'
+    RE = re.compile(r'(?:^|\n)::: ?([:a-zA-Z0-9_.]*) *(?:\n|$)')
+    RE_SPACES = re.compile('  +')
+
+    def test(self, parent, block):
+        sibling = self.lastChild(parent)
+        return self.RE.search(block) or \
+            (block.startswith(' ' * self.tab_length) and sibling is not None and
+             sibling.get('class', '').find(self.CLASSNAME) != -1)
+
+    def run(self, parent, blocks):
+        sibling = self.lastChild(parent)
+        block = blocks.pop(0)
+        m = self.RE.search(block)
+
+        if m:
+            block = block[m.end():]  # removes the first line
+
+        block, theRest = self.detab(block)
+
+        if m:
+            full_string = m.group(1)
+            import_string, _, name_string = full_string.partition(':')
+            attribute = import_from_string(full_string)
+            attribute_signature = inspect.signature(attribute)
+
+            autodoc_div = etree.SubElement(parent, 'div')
+            autodoc_div.set('class', self.CLASSNAME)
+
+            # Eg: `some_module.attribute_name`
+            headline_elem = etree.SubElement(autodoc_div, 'p')
+            import_elem = etree.SubElement(headline_elem, 'code')
+            import_elem.text = import_string + '.'
+            import_elem.set('class', 'autodoc-import')
+            name_elem = etree.SubElement(headline_elem, 'code')
+            name_elem.text = name_string
+            name_elem.set('class', 'autodoc-name')
+
+            # Eg: `(a, b='default', **kwargs)``
+            bracket_elem = etree.SubElement(headline_elem, 'span')
+            bracket_elem.text = '('
+            bracket_elem.set('class', 'autodoc-punctuation')
+
+            for param, is_last in self.last_iter(self.get_params(attribute_signature)):
+                param_elem = etree.SubElement(headline_elem, 'em')
+                param_elem.text = param
+                param_elem.set('class', 'autodoc-param')
+
+                if not is_last:
+                    comma_elem = etree.SubElement(headline_elem, 'span')
+                    comma_elem.text = ', '
+                    comma_elem.set('class', 'autodoc-punctuation')
+
+            bracket_elem = etree.SubElement(headline_elem, 'span')
+            bracket_elem.text = ')'
+            bracket_elem.set('class', 'autodoc-punctuation')
+
+            # Render docstring
+            docstring_elem = etree.SubElement(autodoc_div, 'div')
+            docstring_elem.set('class', 'autodoc-docstring')
+
+            docstring = self.trim(attribute.__doc__)
+            self.parser.parseChunk(docstring_elem, docstring)
+
+        else:
+            self.parser.parseChunk(sibling, block)
+
+        if theRest:
+            # This block contained unindented line(s) after the first indented
+            # line. Insert these lines as the first block of the master blocks
+            # list for future processing.
+            blocks.insert(0, theRest)
+
+    def get_params(self, signature: inspect.Signature) -> typing.List[str]:
+        params = []
+        render_pos_only_separator = True
+        render_kw_only_separator = True
+
+        for parameter in signature.parameters.values():
+            value = parameter.name
+            if parameter.default is not parameter.empty:
+                value = f'{value}={parameter.default!r}'
+
+            if parameter.kind is parameter.VAR_POSITIONAL:
+                render_kw_only_separator = False
+                value = f'*{value}'
+            elif parameter.kind is parameter.VAR_KEYWORD:
+                value = f'**{value}'
+            elif parameter.kind is parameter.POSITIONAL_ONLY:
+                if render_pos_only_separator:
+                    render_pos_only_separator = False
+                    params.append('/')
+            elif parameter.kind is parameter.KEYWORD_ONLY:
+                if render_kw_only_separator:
+                    render_kw_only_separator = False
+                    params.append('*')
+            params.append(value)
+
+        return params
+
+    def last_iter(self, it: typing.Iterator) -> typing.Iterator:
+        """
+        Given an iteratable, return a two-tuple (item, is_last) iterable.
+
+        See: https://stackoverflow.com/a/1633483/596689
+        """
+        it = iter(it)
+        item = next(it)
+        is_last = False
+
+        for next_item in it:
+            yield item, is_last
+            item = next_item
+
+        is_last = True
+        yield item, is_last
+
+    def trim(self, docstring: typing.Optional[str]) -> str:
+        """
+        Trim leading indent from a docstring.
+
+        See: https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
+        """
+        if not docstring:
+            return ''
+
+        # Convert tabs to spaces (following the normal Python rules)
+        # and split into a list of lines:
+        lines = docstring.expandtabs().splitlines()
+        # Determine minimum indentation (first line doesn't count):
+        indent = 1000
+        for line in lines[1:]:
+            stripped = line.lstrip()
+            if stripped:
+                indent = min(indent, len(line) - len(stripped))
+
+        # Remove indentation (first line is special):
+        trimmed = [lines[0].strip()]
+        if indent < 1000:
+            for line in lines[1:]:
+                trimmed.append(line[indent:].rstrip())
+
+        # Strip off trailing and leading blank lines:
+        while trimmed and not trimmed[-1]:
+            trimmed.pop()
+        while trimmed and not trimmed[0]:
+            trimmed.pop(0)
+
+        # Return a single string:
+        return '\n'.join(trimmed)
+
+
+class AutoDocExtension(Extension):
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.registerExtension(self)
+        md.parser.blockprocessors.register(AutoDocProcessor(md.parser), 'autodoc', 110)

--- a/mkdocs2/markdown_extensions/convert_urls.py
+++ b/mkdocs2/markdown_extensions/convert_urls.py
@@ -39,4 +39,4 @@ class ConvertURLs(Extension):
 
     def extendMarkdown(self, md: Markdown) -> None:
         url_processor = URLProcessor(self.convert_url)
-        md.treeprocessors.register(url_processor, "url", 10)
+        md.treeprocessors.register(url_processor, "convert_url", 10)

--- a/scripts/test
+++ b/scripts/test
@@ -10,7 +10,7 @@ fi
 
 set -x
 
-${PREFIX}pytest --cov ${PACKAGE} --cov tests --cov-fail-under 100 ./tests/
+${PREFIX}pytest --cov ${PACKAGE} --cov tests --cov-fail-under 100 ./tests/ --cov-report term-missing
 ${PREFIX}mypy --ignore-missing-imports --disallow-untyped-defs ${PACKAGE}
 if [[ ${PYTHONVERSION} == "3.6" ]]; then
     ${PREFIX}black ${PACKAGE} tests --check

--- a/tests/import_examples/__init__.py
+++ b/tests/import_examples/__init__.py
@@ -1,0 +1,1 @@
+from .example_module import example_function

--- a/tests/import_examples/__init__.py
+++ b/tests/import_examples/__init__.py
@@ -1,1 +1,1 @@
-from .example_module import example_function
+from .example_module import example_function, ExampleClass

--- a/tests/import_examples/example_module.py
+++ b/tests/import_examples/example_module.py
@@ -1,0 +1,5 @@
+def example_function(a, b=None, **kwargs):
+    """
+    This is my *docstring*.
+    """
+    pass  # pragma: nocover

--- a/tests/import_examples/example_module.py
+++ b/tests/import_examples/example_module.py
@@ -3,3 +3,12 @@ def example_function(a, b=None, **kwargs):
     This is my *docstring*.
     """
     pass  # pragma: nocover
+
+
+class ExampleClass:
+    """
+    This is my *docstring*.
+    """
+
+    def __init__(a, b=None, **kwargs):
+        pass  # pragma: nocover

--- a/tests/import_examples/raise_unrelated_import_error.py
+++ b/tests/import_examples/raise_unrelated_import_error.py
@@ -1,0 +1,4 @@
+import invalidmodulename
+
+
+SOME_ATTRIBUTE = 123  # pragma: nocover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,8 +50,8 @@ nav:
         Topic A: topics/a.md
         Topic B: topics/b.md
 convertors:
-    - mkdocs2.convertors:MarkdownPages
-    - mkdocs2.convertors:StaticFiles
+    - mkdocs2.convertors.MarkdownPages
+    - mkdocs2.convertors.StaticFiles
 """,
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,9 +41,9 @@ def test_build(tmpdir):
             "Topics": {"Topic A": "topics/a.md", "Topic B": "topics/b.md"},
         },
         "convertors": [
-            "mkdocs2.convertors:MarkdownPages",
-            "mkdocs2.convertors:CodeHighlight",
-            "mkdocs2.convertors:StaticFiles",
+            "mkdocs2.convertors.MarkdownPages",
+            "mkdocs2.convertors.CodeHighlight",
+            "mkdocs2.convertors.StaticFiles",
         ],
     }
     mkdocs2.build(config=config)
@@ -60,11 +60,14 @@ def test_build(tmpdir):
 
 
 def test_import_from_string():
-    cls = import_from_string("mkdocs2.convertors:MarkdownPages")
+    cls = import_from_string("mkdocs2.convertors.MarkdownPages")
     assert issubclass(cls, mkdocs2.types.Convertor)
 
     with pytest.raises(ValueError):
-        import_from_string("invalidmodulename.convertors:MarkdownPages")
+        import_from_string("invalidmodulename.convertors.MarkdownPages")
 
     with pytest.raises(ValueError):
-        import_from_string("mkdocs2.convertors:InvalidAttribute")
+        import_from_string("mkdocs2.convertors.InvalidAttribute")
+
+    with pytest.raises(ImportError):
+        import_from_string("tests.import_examples.raise_unrelated_import_error.SOME_ATTRIBUTE")

--- a/tests/test_markdown_extensions/test_autodoc.py
+++ b/tests/test_markdown_extensions/test_autodoc.py
@@ -4,7 +4,7 @@ from mkdocs2.markdown_extensions.autodoc import AutoDocExtension, trim_docstring
 import inspect
 
 
-def test_autodoc():
+def test_autodoc_function():
     md = Markdown(extensions=[AutoDocExtension()])
     text = md.convert(
         """
@@ -14,12 +14,48 @@ This is an API reference.
 
 ::: import_examples.example_function
     :docstring:
-Some trailing text.
 """)
     assert text == """<h1>API reference</h1>
 <p>This is an API reference.</p>
 <div class="autodoc">
-<p><code class="autodoc-import">import_examples.example_function.</code><code class="autodoc-name"></code><span class="autodoc-punctuation">(</span><em class="autodoc-param">a</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">b=None</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">**kwargs</em><span class="autodoc-punctuation">)</span></p>
+<p><code class="autodoc-import">import_examples.</code><code class="autodoc-name">example_function</code><span class="autodoc-punctuation">(</span><em class="autodoc-param">a</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">b=None</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">**kwargs</em><span class="autodoc-punctuation">)</span></p>
+<div class="autodoc-docstring">
+<p>This is my <em>docstring</em>.</p>
+</div>
+</div>"""
+
+
+def test_autodoc_class():
+    md = Markdown(extensions=[AutoDocExtension()])
+    text = md.convert(
+        """
+# API reference
+
+This is an API reference.
+
+::: import_examples.ExampleClass
+    :docstring:
+""")
+    assert text == """<h1>API reference</h1>
+<p>This is an API reference.</p>
+<div class="autodoc">
+<p><em>class </em><code class="autodoc-import">import_examples.</code><code class="autodoc-name">ExampleClass</code><span class="autodoc-punctuation">(</span><em class="autodoc-param">b=None</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">**kwargs</em><span class="autodoc-punctuation">)</span></p>
+<div class="autodoc-docstring">
+<p>This is my <em>docstring</em>.</p>
+</div>
+</div>"""
+
+
+def test_autodoc_trailing_text():
+    md = Markdown(extensions=[AutoDocExtension()])
+    text = md.convert(
+        """
+::: import_examples.example_function
+    :docstring:
+Some trailing text.
+""")
+    assert text == """<div class="autodoc">
+<p><code class="autodoc-import">import_examples.</code><code class="autodoc-name">example_function</code><span class="autodoc-punctuation">(</span><em class="autodoc-param">a</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">b=None</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">**kwargs</em><span class="autodoc-punctuation">)</span></p>
 <div class="autodoc-docstring">
 <p>This is my <em>docstring</em>.</p>
 </div>


### PR DESCRIPTION
Adds an `autodoc` extension, that uses a `:::` syntax to introduce auto-documented API blocks.

Example:

```markdown
# API reference

This is an API reference.

::: import_examples.example_function
    :docstring:
```